### PR TITLE
Revert back to old sqlalchemy dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ requirements:
     - adlfs >=2023.1.0,<2024.8.0
     - gcsfs >=2023.1.0,<2024.1.0
     - psycopg2-binary >=2.9.6
-    - sqlalchemy >=2.0.18,<3.0.0
+    - sqlalchemy >=1.4.0,<3.0.0
     - getdaft >=0.2.12
     - numpy >=1.22.4
 


### PR DESCRIPTION
Sqlalchemy >= 2.0 breaks pandas < 2.0, given that it is defined in the package dependencies that we are trying to support pandas < 2.0, we need to keep support for Sqlalchemy < 2.  Also sqlalchemy is only needed by pyiceberg for sql-lite and postgress dependencies, and not the usual use cases, so its probably better to allow pyiceberg to be used in projects that need pandas < 2, and make the dependency process a little more error prone for people using it with postgres or sql lite, rather than the other way as it currently is